### PR TITLE
修复 样式值以0开头时应去掉单位的检查 的bug

### DIFF
--- a/ckstyle/plugins/FEDNoUnitAfterZero.py
+++ b/ckstyle/plugins/FEDNoUnitAfterZero.py
@@ -11,9 +11,6 @@ class FEDNoUnitAfterZero(RuleChecker):
         def startsWithZero(value):
             return value.startswith('0') and value != '0' and value[1] != '.'
 
-        if startsWithZero(rule.value):
-            return False
-
         values = rule.value.split(' ')
         for v in values:
             if startsWithZero(v.strip()):

--- a/tests/unit/check/FEDNoUnitAfterZero.css
+++ b/tests/unit/check/FEDNoUnitAfterZero.css
@@ -22,3 +22,7 @@
 .test-padding {
     padding: 1px 0px;
 }
+
+.test-padding-start-with-zero {
+    padding: 0 1px 0 1px;
+}


### PR DESCRIPTION
之前对`padding: 0 1px 0 1px;` 这种样式会报错
